### PR TITLE
Add backport to unbreak build on R-4.5

### DIFF
--- a/src/h5mread_index.c
+++ b/src/h5mread_index.c
@@ -10,6 +10,11 @@
 #include "TouchedChunks.h"
 
 #include <R_ext/Altrep.h>  /* only for DATAPTR_RW() */
+#include <Rversion.h>
+#if R_VERSION < R_Version(4, 6, 0)
+# define DATAPTR_RW(x) DATAPTR(x)
+#endif
+
 #include <stdlib.h>  /* for malloc, free */
 #include <string.h>  /* for memcmp */
 //#include <time.h>

--- a/src/h5mread_startscounts.c
+++ b/src/h5mread_startscounts.c
@@ -9,6 +9,11 @@
 #include "h5mread_helpers.h"
 
 #include <R_ext/Altrep.h>  /* only for DATAPTR_RW() */
+#include <Rversion.h>
+#if R_VERSION < R_Version(4, 6, 0)
+# define DATAPTR_RW(x) DATAPTR(x)
+#endif
+
 #include <stdlib.h>  /* for malloc, free */
 //#include <time.h>
 


### PR DESCRIPTION
I know this package is intended for bioc-devel/r-devel, but several components of R-universe run r-release to render things, so it would be nice if we can keep supporting that version too for now.

See https://cran.r-project.org/doc/manuals/r-devel/R-exts.html#Some-backports